### PR TITLE
Assembler API cleanup

### DIFF
--- a/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerRegisterTests.cs
+++ b/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerRegisterTests.cs
@@ -289,7 +289,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 			}
 
 			{
-				var assembler = Assembler.Create(64, new CodeWriterImpl());
+				var assembler = Assembler.Create(64);
 				var label = assembler.CreateLabel("Check");
 				var m = __[label];
 				Assert.Equal(new MemoryOperand(Register.RIP, Register.None, 1, 1, 1), m.ToMemoryOperand(64));

--- a/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerTests64.cs
+++ b/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerTests64.cs
@@ -27,7 +27,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 			{
 				var assembler = Assembler.Create(Bitness);
 				var writer = new CodeWriterImpl();
-				var ex = Assert.Throws<InvalidOperationException>(() => assembler.rep.Encode(writer));
+				var ex = Assert.Throws<InvalidOperationException>(() => assembler.rep.Assemble(writer));
 				Assert.Contains("Unused prefixes", ex.Message);
 			}
 			{
@@ -35,7 +35,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 				var label = assembler.CreateLabel(("BadLabel"));
 				assembler.Label(ref label);
 				var writer = new CodeWriterImpl();
-				var ex = Assert.Throws<InvalidOperationException>(() => assembler.Encode(writer));
+				var ex = Assert.Throws<InvalidOperationException>(() => assembler.Assemble(writer));
 				Assert.Contains("Unused label", ex.Message);
 			}
 		}
@@ -52,7 +52,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 				c.nop();
 				
 				var writer = new CodeWriterImpl();
-				var result = c.Encode(writer, 0x100, BlockEncoderOptions.ReturnNewInstructionOffsets);
+				var result = c.Assemble(writer, 0x100, BlockEncoderOptions.ReturnNewInstructionOffsets);
 				var label1RIP = result.GetLabelRIP(label1);
 				Assert.Equal((ulong)0x103, label1RIP);
 			}
@@ -71,7 +71,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 				Assert.Throws<ArgumentException>(() => c.Label(ref label1));
 				
 				var writer = new CodeWriterImpl();
-				var result = c.Encode(writer);
+				var result = c.Assemble(writer);
 				// Will throw without BlockEncoderOptions.ReturnNewInstructionOffsets
 				Assert.Throws<ArgumentOutOfRangeException>(() => result.GetLabelRIP(label1));
 			}

--- a/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerTestsBase.cs
+++ b/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerTestsBase.cs
@@ -62,7 +62,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 
 			// Encode the instruction first to get any errors
 			var writer = new CodeWriterImpl();
-			assembler.Encode(writer, 0, (flags & LocalOpCodeFlags.BranchUlong) != 0 ? BlockEncoderOptions.None : BlockEncoderOptions.DontFixBranches);
+			assembler.Assemble(writer, 0, (flags & LocalOpCodeFlags.BranchUlong) != 0 ? BlockEncoderOptions.None : BlockEncoderOptions.DontFixBranches);
 			
 			// Check that the instruction is the one expected
 			if ((flags & LocalOpCodeFlags.Broadcast) != 0) {
@@ -224,7 +224,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 			fAsm(assembler);
 
 			var writer = new CodeWriterImpl();
-			assembler.Encode(writer);
+			assembler.Assemble(writer);
 			var buffer = writer.ToArray();
 			
 			Assert.Equal(sizeOfT * data.Length, buffer.Length);

--- a/src/csharp/Intel/Iced/Intel/Assembler/Assembler.cs
+++ b/src/csharp/Intel/Iced/Intel/Assembler/Assembler.cs
@@ -373,25 +373,25 @@ namespace Iced.Intel {
 		}
 
 		/// <summary>
-		/// Encode the instructions of this assembler with the specified options.
+		/// Assembles the instructions of this assembler with the specified options.
 		/// </summary>
 		/// <param name="writer">The code writer.</param>
 		/// <param name="baseRIP">Base RIP address.</param>
 		/// <param name="options">Encoding options.</param>
 		/// <returns></returns>
 		/// <exception cref="InvalidOperationException"></exception>
-		public AssemblerResult Encode(CodeWriter writer, ulong baseRIP = 0, BlockEncoderOptions options = BlockEncoderOptions.None) {
+		public AssemblerResult Assemble(CodeWriter writer, ulong baseRIP = 0, BlockEncoderOptions options = BlockEncoderOptions.None) {
 			if (writer is null)
 				ThrowHelper.ThrowArgumentNullException_writer();
 
-			if (!TryEncode(writer, baseRIP, out var errorMessage, out var assemblerResult, options)) {
+			if (!TryAssemble(writer, baseRIP, out var errorMessage, out var assemblerResult, options)) {
 				throw new InvalidOperationException(errorMessage);
 			}
 			return assemblerResult;
 		}
 
 		/// <summary>
-		/// Tries to encode the instructions of this assembler with the specified options.
+		/// Tries to assemble the instructions of this assembler with the specified options.
 		/// </summary>
 		/// <param name="writer">The code writer.</param>
 		/// <param name="baseRIP">Base RIP address.</param>
@@ -399,7 +399,7 @@ namespace Iced.Intel {
 		/// <param name="assemblerResult">The assembler result.</param>
 		/// <param name="options">Encoding options.</param>
 		/// <returns><c>true</c> if the encoding was successful; <c>false</c> otherwise.</returns>
-		public bool TryEncode(CodeWriter writer, ulong baseRIP, out string? errorMessage, out AssemblerResult assemblerResult, BlockEncoderOptions options = BlockEncoderOptions.None) {
+		public bool TryAssemble(CodeWriter writer, ulong baseRIP, out string? errorMessage, out AssemblerResult assemblerResult, BlockEncoderOptions options = BlockEncoderOptions.None) {
 			if (writer is null)
 				ThrowHelper.ThrowArgumentNullException_writer();
 

--- a/src/csharp/Intel/Iced/Intel/Assembler/AssemblerResult.cs
+++ b/src/csharp/Intel/Iced/Intel/Assembler/AssemblerResult.cs
@@ -27,7 +27,7 @@ using System;
 namespace Iced.Intel
 {
 	/// <summary>
-	/// Result of <see cref="Assembler.Encode"/>.
+	/// Result of <see cref="Assembler.Assemble"/>.
 	/// </summary>
 	public readonly struct AssemblerResult {
 		
@@ -61,7 +61,7 @@ namespace Iced.Intel
 		public ulong GetLabelRIP(in Label label) {
 			if (label.IsEmpty) throw new ArgumentException($"Invalid label. Must be created via {nameof(Assembler)}.{nameof(Assembler.CreateLabel)}", nameof(label));
 			if (label.InstructionIndex < 0) throw new ArgumentException($"The label is not associated with an instruction index. It must be emitted via {nameof(Assembler)}.{nameof(Assembler.Label)}.", nameof(label));
-			if (BlockEncoderResult.NewInstructionOffsets == null || label.InstructionIndex >= BlockEncoderResult.NewInstructionOffsets.Length) throw new ArgumentOutOfRangeException(nameof(label), $"The label instruction index {label.InstructionIndex} is out of range of the instruction offsets results {BlockEncoderResult.NewInstructionOffsets?.Length ?? 0}. Did you forget to pass {nameof(BlockEncoderOptions)}.{nameof(BlockEncoderOptions.ReturnNewInstructionOffsets)} to {nameof(Assembler)}.{nameof(Assembler.Encode)}/{nameof(Assembler.TryEncode)}?");
+			if (BlockEncoderResult.NewInstructionOffsets == null || label.InstructionIndex >= BlockEncoderResult.NewInstructionOffsets.Length) throw new ArgumentOutOfRangeException(nameof(label), $"The label instruction index {label.InstructionIndex} is out of range of the instruction offsets results {BlockEncoderResult.NewInstructionOffsets?.Length ?? 0}. Did you forget to pass {nameof(BlockEncoderOptions)}.{nameof(BlockEncoderOptions.ReturnNewInstructionOffsets)} to {nameof(Assembler)}.{nameof(Assembler.Assemble)}/{nameof(Assembler.TryAssemble)}?");
 			return BaseRIP + BlockEncoderResult.NewInstructionOffsets[label.InstructionIndex];
 		}
 	}


### PR DESCRIPTION
Small PR to cleanup the assembler API:

- Remove writer from constructor, as it is only used when encoding. Move it as an argument to Encode/TryEncode instead.
- Add some additional infos to README.md