### PR TITLE
Assembler.Assemble and ctor Assembler

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ public static class AssemblerPlay
 {
 	public static MemoryStream GenerateCode()
 	{
-		var c = Assembler.Create(64);
+		var c = new Assembler(64);
 
 		c.push(r15);
 		c.mov(r15, rsi);
@@ -643,7 +643,7 @@ public static class AssemblerPlay
 
 		var stream = new MemoryStream();
 		var writer = new StreamCodeWriter(stream)
-		c.Encode(writer);
+		c.Assemble(writer);
 
 		return stream;
 	}
@@ -668,7 +668,7 @@ public static class AssemblerPlay
 {
 	public static MemoryStream GenerateCode()
 	{
-		var c = Assembler.Create(64);
+		var c = new Assembler(64);
 
 		// Create a label
 		var label1 = c.CreateLabel();
@@ -686,7 +686,7 @@ public static class AssemblerPlay
 
 		var stream = new MemoryStream();
 		var writer = new StreamCodeWriter(stream)
-		c.Encode(writer);
+		c.Assemble(writer);
 
 		return stream;
 	}

--- a/src/csharp/Intel/Generator/Assembler/CSharp/CSharpAssemblerSyntaxGenerator.cs
+++ b/src/csharp/Intel/Generator/Assembler/CSharp/CSharpAssemblerSyntaxGenerator.cs
@@ -108,7 +108,7 @@ namespace Generator.Assembler.CSharp {
 				writer.WriteLine($"namespace {CSharpConstants.IcedNamespace} {{");
 				using (writer.Indent()) {
 					writer.WriteLine("using System;");
-					writer.WriteLine("public sealed partial class Assembler {");
+					writer.WriteLine("public partial class Assembler {");
 					using (writer.Indent()) {
 						foreach (var group in groups) {
 							var renderArgs = GetRenderArgs(group);

--- a/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerRegisterTests.cs
+++ b/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerRegisterTests.cs
@@ -289,7 +289,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 			}
 
 			{
-				var assembler = Assembler.Create(64);
+				var assembler = new Assembler(64);
 				var label = assembler.CreateLabel("Check");
 				var m = __[label];
 				Assert.Equal(new MemoryOperand(Register.RIP, Register.None, 1, 1, 1), m.ToMemoryOperand(64));

--- a/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerTests64.cs
+++ b/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerTests64.cs
@@ -25,13 +25,13 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 		[Fact]
 		public void TestInvalidStateAssembler() {
 			{
-				var assembler = Assembler.Create(Bitness);
+				var assembler = new Assembler(Bitness);
 				var writer = new CodeWriterImpl();
 				var ex = Assert.Throws<InvalidOperationException>(() => assembler.rep.Assemble(writer));
 				Assert.Contains("Unused prefixes", ex.Message);
 			}
 			{
-				var assembler = Assembler.Create(Bitness);
+				var assembler = new Assembler(Bitness);
 				var label = assembler.CreateLabel(("BadLabel"));
 				assembler.Label(ref label);
 				var writer = new CodeWriterImpl();
@@ -43,7 +43,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 		[Fact]
 		public void TestLabelRIP() {
 			{
-				var c = Assembler.Create(Bitness);
+				var c = new Assembler(Bitness);
 				var label1 = c.CreateLabel();
 				c.nop();
 				c.nop();
@@ -57,7 +57,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 				Assert.Equal((ulong)0x103, label1RIP);
 			}
 			{
-				var c = Assembler.Create(Bitness);
+				var c = new Assembler(Bitness);
 				var label1 = c.CreateLabel();
 				c.nop();
 				c.Label(ref label1);				

--- a/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerTestsBase.cs
+++ b/src/csharp/Intel/Iced.UnitTests/Intel/AssemblerTests/AssemblerTestsBase.cs
@@ -40,7 +40,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 		public int Bitness => _bitness;
 		
 		protected void TestAssembler(Action<Assembler> fAsm, Instruction expectedInst, LocalOpCodeFlags flags = LocalOpCodeFlags.None) {
-			var assembler = Assembler.Create(_bitness);
+			var assembler = new Assembler(_bitness);
 			
 			// Encode the instruction
 			if ((flags & LocalOpCodeFlags.PreferVex) != 0) {
@@ -219,7 +219,7 @@ namespace Iced.UnitTests.Intel.AssemblerTests {
 		}
 
 		protected unsafe void TestAssemblerDeclareData<T>(Action<Assembler> fAsm, T[] data) where T : unmanaged {
-			var assembler = Assembler.Create(Bitness);
+			var assembler = new Assembler(Bitness);
 			var sizeOfT = sizeof(T);
 			fAsm(assembler);
 

--- a/src/csharp/Intel/Iced/Intel/Assembler/Assembler.cs
+++ b/src/csharp/Intel/Iced/Intel/Assembler/Assembler.cs
@@ -31,7 +31,7 @@ namespace Iced.Intel {
 	/// <summary>
 	/// High-Level Assembler.
 	/// </summary>
-	public sealed partial class Assembler {
+	public partial class Assembler {
 
 		readonly List<Instruction> _instructions;
 		ulong _currentLabelId;
@@ -41,9 +41,16 @@ namespace Iced.Intel {
 		/// <summary>
 		/// Creates a new instance of this assembler 
 		/// </summary>
-		/// <param name="bitness">Bitness</param>
-		Assembler(int bitness) {
-			Debug.Assert(bitness == 16 || bitness == 32 || bitness == 64);
+		/// <param name="bitness">The assembler instruction set bitness, either 16, 32 or 64 bit.</param>
+		public Assembler(int bitness) {
+			switch (bitness) {
+			case 16:
+			case 32:
+			case 64:
+				break;
+			default:
+				throw new ArgumentOutOfRangeException("Only 16, 32 or 64 bitness are supported", nameof(bitness));
+			}
 			Bitness = bitness;
 			_instructions = new List<Instruction>();
 			_label = default;
@@ -79,24 +86,6 @@ namespace Iced.Intel {
 			_currentLabelId = 0;
 			_label = default;
 			_nextPrefixFlags = PrefixFlags.None;
-		}
-
-		/// <summary>
-		/// Creates a new <see cref="Assembler"/>.
-		/// </summary>
-		/// <param name="bitness">Bitness of the assembler</param>
-		/// <returns></returns>
-		/// <exception cref="ArgumentNullException"></exception>
-		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		public static Assembler Create(int bitness) {
-			switch (bitness) {
-			case 16:
-			case 32:
-			case 64:
-				return new Assembler(bitness);
-			default:
-				throw new ArgumentOutOfRangeException(nameof(bitness));
-			}
 		}
 
 		/// <summary>

--- a/src/csharp/Intel/Iced/Intel/Assembler/Assembler.g.cs
+++ b/src/csharp/Intel/Iced/Intel/Assembler/Assembler.g.cs
@@ -28,7 +28,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #if !NO_ENCODER
 namespace Iced.Intel {
 	using System;
-	public sealed partial class Assembler {
+	public partial class Assembler {
 		/// <summary>aaa instruction.<br/>
 		/// <br/>
 		/// <br/>


### PR DESCRIPTION
This PR is:

- Renaming `Assembler.Encode/TryEncode` to `Assemble/TryAssemble`
- Making `Assembler(bitness)` public and remove sealed to allow subclassing scenarios.