### PR TITLE
Remove unnecessary null check

### DIFF
--- a/src/csharp/Intel/Iced/Intel/Assembler/Assembler.cs
+++ b/src/csharp/Intel/Iced/Intel/Assembler/Assembler.cs
@@ -454,9 +454,6 @@ namespace Iced.Intel {
 		/// <returns></returns>
 		/// <exception cref="InvalidOperationException"></exception>
 		public AssemblerResult Assemble(CodeWriter writer, ulong rip, BlockEncoderOptions options = BlockEncoderOptions.None) {
-			if (writer is null)
-				ThrowHelper.ThrowArgumentNullException_writer();
-
 			if (!TryAssemble(writer, rip, out var errorMessage, out var assemblerResult, options)) {
 				throw new InvalidOperationException(errorMessage);
 			}


### PR DESCRIPTION
The `Assemble()` only calls `TryAssemble()` method which already checks if the `writer` parameter is null. It might not be necessary to perform a null check twice.