### PR TITLE
Override InstructionList.ToString()

### DIFF
--- a/src/csharp/Intel/Iced/Intel/InstructionList.cs
+++ b/src/csharp/Intel/Iced/Intel/InstructionList.cs
@@ -600,7 +600,7 @@ namespace Iced.Intel {
 		public override string ToString() {
 			StringBuilder sb = new StringBuilder();
 			foreach (Instruction instruction in elements)
-				sb.Append(instruction + Environment.NewLine);
+				sb.AppendLine(instruction.ToString());
 			return sb.ToString();
 		}
 	}

--- a/src/csharp/Intel/Iced/Intel/InstructionList.cs
+++ b/src/csharp/Intel/Iced/Intel/InstructionList.cs
@@ -598,6 +598,8 @@ namespace Iced.Intel {
 		/// </summary>
 		/// <returns></returns>
 		public override string ToString() {
+			if (count == 0)
+				return string.Empty;
 			StringBuilder sb = new StringBuilder();
 			foreach (Instruction instruction in elements)
 				sb.AppendLine(instruction.ToString());

--- a/src/csharp/Intel/Iced/Intel/InstructionList.cs
+++ b/src/csharp/Intel/Iced/Intel/InstructionList.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Iced.Intel {
 	/// <summary>
@@ -590,6 +591,17 @@ namespace Iced.Intel {
 			var res = new Instruction[count];
 			Array.Copy(elements, 0, res, 0, res.Length);
 			return res;
+		}
+
+		/// <summary>
+		/// Returns a string with each instruction per line
+		/// </summary>
+		/// <returns></returns>
+		public override string ToString() {
+			StringBuilder sb = new StringBuilder();
+			foreach (Instruction instruction in elements)
+				sb.Append(instruction + Environment.NewLine);
+			return sb.ToString();
 		}
 	}
 }


### PR DESCRIPTION
This is very useful especially when using string interpolation the user can pass the list directly instead of iterating and allocating a temporarily string himself. I don't see any malus either as for debugging the class has a `InstructionListDebugView` attribute 🤷‍♂️