### PR TITLE
Fixed negate with overflow in Intel formatter.

### DIFF
--- a/src/rust/iced-x86/src/formatter/intel/mod.rs
+++ b/src/rust/iced-x86/src/formatter/intel/mod.rs
@@ -702,7 +702,7 @@ impl IntelFormatter {
 						number_kind = NumberKind::Int8;
 						if (imm8 as i8) < 0 {
 							output.write("-", FormatterTextKind::Operator);
-							imm8 = -(imm8 as i8) as u8;
+							imm8 = (imm8 as i8).wrapping_neg() as u8;
 						}
 					} else {
 						imm64 = imm8 as u64;
@@ -753,7 +753,7 @@ impl IntelFormatter {
 						number_kind = NumberKind::Int16;
 						if (imm16 as i16) < 0 {
 							output.write("-", FormatterTextKind::Operator);
-							imm16 = -(imm16 as i16) as u16;
+							imm16 = (imm16 as i16).wrapping_neg() as u16;
 						}
 					} else {
 						imm64 = imm16 as u64;
@@ -804,7 +804,7 @@ impl IntelFormatter {
 						number_kind = NumberKind::Int32;
 						if (imm32 as i32) < 0 {
 							output.write("-", FormatterTextKind::Operator);
-							imm32 = -(imm32 as i32) as u32;
+							imm32 = (imm32 as i32).wrapping_neg() as u32;
 						}
 					} else {
 						imm64 = imm32 as u64;
@@ -857,7 +857,7 @@ impl IntelFormatter {
 						number_kind = NumberKind::Int64;
 						if (imm64 as i64) < 0 {
 							output.write("-", FormatterTextKind::Operator);
-							imm64 = -(imm64 as i64) as u64;
+							imm64 = (imm64 as i64).wrapping_neg() as u64;
 						}
 					} else {
 						number_kind = NumberKind::UInt64;


### PR DESCRIPTION
If the immediate value happened to be -MIN (e.g. -128 for an i8), negating that value would cause an `attempt to negate with overflow` crash in debug builds.
This fix uses wrapping_neg instead, which would wrap -in::MIN to in::MIN, which when cast to the unsigned type will give the expected result.